### PR TITLE
Make all plugins test happy in logstash-core

### DIFF
--- a/logstash-input-neo4j.gemspec
+++ b/logstash-input-neo4j.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-neo4j'
-  s.version         = '0.9.1'
+  s.version         = '0.9.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Logstash Input for Neo4j"
   s.description     = "Output events to Neo4j"

--- a/spec/inputs/neo4j-client_spec.rb
+++ b/spec/inputs/neo4j-client_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require_relative "../spec_helper"
 
 describe "Neo4jrb::Client", :integration => true do
 

--- a/spec/inputs/neo4j_spec.rb
+++ b/spec/inputs/neo4j_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require_relative "../spec_helper"
 require "logstash/plugin"
 require "logstash/json"
 


### PR DESCRIPTION
This PR workarround the fact that this project is using a generic spec_helper to load some stuff and that this is not compatible with the way logstash-core runs the all_plugins test. For now doing a require_relative is the best solution to get this fix.

It also bumps the version to this is released and available.
